### PR TITLE
Add Windows instructions, and update the example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ PyLBFGS is a Python 3 wrapper of the [libLBFGS][libLBFGS] library -- a C port (w
 
 At this time, only the Orthant-Wise Limited-memory Quasi-Newton (OWL-QN) algorithm is exposed (although very little work would be required to expose the full [libLBFGS][libLBFGS] implementation).
 
-Also note that PyLBFGS has only been compiled and tested with Python 3 on a 64-bit Ubuntu machine. It should work in other environments... but tweaking the installation commands is a task left to the reader.
+Also note that PyLBFGS has only been compiled and tested with Python 3 on a 64-bit Ubuntu machine and a 64-bit Windows machine. It should work in other environments... but tweaking the installation commands is a task left to the reader.
 
+In order to compile on Windows one simply has to remove the "runtime_library_dirs" line in setup.py, and modify the library/include dirs to point to your install. You must also add the x64 build target when building libLBFGS in visual studio if compiling for a x64 machine and version of python.
 
 
 Install
@@ -27,7 +28,7 @@ Install
 
 3. Setup and activate a virtual environment (modify the Python version if necessary):
 
-        virtualenv -p python3.6 --prompt="(pylbfgs) " .venv
+        virtualenv -p python3.12.9 --prompt="(pylbfgs) " .venv
         . .venv/bin/activate
 
 4. Install the project:
@@ -83,7 +84,7 @@ Examples
 
 See the *example.py* script for an advanced example in which we use compressed sensing to reconstruct a sparsely sampled image. A more thorough example of compressed sensing (using PyLBFGS) can be found on my weblog [here][blog_post].
 
-    pip install Pillow==5.0.0 scipy==1.0.0 matplotlib==2.1.2
+    pip install Pillow==11.1.0 scipy==1.15.2 matplotlib==3.1.0
     python example.py
 
 

--- a/example.py
+++ b/example.py
@@ -269,9 +269,9 @@ def main():
 
     # display the result
     f, ax = plt.subplots(1, 3, figsize=(14, 4))
-    ax[0].imshow(X, cmap='hot', interpolation='none')
-    ax[1].imshow(Xm, cmap='hot', interpolation='none')
-    ax[2].imshow(Xa, cmap='hot', interpolation='none')
+    ax[0].imshow(X, cmap='hot', interpolation='none',vmin=0, vmax=255)
+    ax[1].imshow(Xm, cmap='hot', interpolation='none',vmin=0, vmax=255)
+    ax[2].imshow(Xa, cmap='hot', interpolation='none',vmin=0, vmax=255)
     plt.show()
 
 

--- a/example.py
+++ b/example.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 import scipy.fftpack as spfft
 import scipy.ndimage as spimg
+import imageio
 import matplotlib.pyplot as plt
 from pylbfgs import owlqn
 
@@ -178,8 +179,12 @@ def main():
 
     global _b_vector, _A_matrix, _image_dims, _ri_vector
 
-    # read image in grayscale, then downscale it
-    Xorig = spimg.imread(ORIG_IMAGE_PATH, flatten=True, mode='L')
+    # read image in, then convert to grayscale and then downscale it
+    Xorig = imageio.imread(ORIG_IMAGE_PATH)
+    # Cast to float before grayscale conversion
+    Xorig = Xorig.astype(float)
+    # Preserving the behaviour of mode='L' from the deprecated scipy.ndimage.imread
+    Xorig = Xorig[:, :, 0] * 299/1000 + Xorig[:, :, 1] * 587/1000 + Xorig[:, :, 2] * 114/1000 
     X = spimg.zoom(Xorig, SCALE)
     ny, nx = X.shape
 


### PR DESCRIPTION
Updated dependencies to more modern versions and since scipy.ndimage.imread no longer exists and as recommended in the docs has been replaced with imageio.imread, preserving mode 'L' using the ITU-R 601-2 luma transform.

Additionally we make sure the imshow() call has vmin=0, vmax=255 for all images, as otherwise the range displayed will be different for the three images, making the reconstruction look worse than it actually is. For example in one run I get the minimum and maximum of the ground truth to be 20 and 247, whilst our reconstruction is 7 and 274. This expanded range makes the reconstruction look like it cannot reproduce dark blacks, or bright whites in the final image.
